### PR TITLE
Update @angular/core peer dependency to support angular 5

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -24,7 +24,7 @@
   "module": "ng2-charts-x.js",
   "typings": "ng2-charts-x.d.ts",
   "peerDependencies": {
-    "@angular/core": "^4.0.0",
+    "@angular/core": ">=4.0.0 <6.0.0",
     "rxjs": "^5.1.0",
     "zone.js": "^0.8.4",
     "chart.js": "^2.6.0",


### PR DESCRIPTION
I haven't noticed any problems on Angular 5. Everything seems to work fine.

Updating this in order to avoid a warning while installing dependencies:

`warning " > ng2-charts-x@2.0.5" has incorrect peer dependency "@angular/core@^4.0.0".`